### PR TITLE
Added 'prepare' method to EmailMessageTemplate class

### DIFF
--- a/emailtemplates/models.py
+++ b/emailtemplates/models.py
@@ -170,6 +170,10 @@ class EmailMessageTemplate(models.Model, EmailMessage):
         No-op to prevent EmailMessage from stomping on the template 
         """
         pass
+    
+    def prepare(self, context={}, to=[]):
+        self.context.update(context)
+        self.to = to
                         
     def send(self, fail_silently=False):
         """


### PR DESCRIPTION
In 'Usage' section of 'Readme' template's 'prepare' method is called, however there is no such method neither in EmailMessageTemplate nor in EmailMessage superclass.
